### PR TITLE
fix(cli): allow filter arguments in test command

### DIFF
--- a/bin/tn.js
+++ b/bin/tn.js
@@ -10,6 +10,7 @@ const tn = program
   .name('tn')
   .version(packageJson.version, '-v, --version', 'Output the current version of tn')
   .description('TabNews command line interface')
+  .allowExcessArguments()
   .configureHelp({ showGlobalOptions: true, sortSubcommands: true, sortOptions: true });
 
 const testCommand = tn


### PR DESCRIPTION
Fixes the bug that appeared with the update of the commander library, which prevents the addition of filters for the execution of tests.

Ref.: [tj/commander.js - Disallow excess arguments #2223](https://github.com/tj/commander.js/pull/2223/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed)