### PR TITLE
Add ESLint rules for useless fragments and unstable nested components on React

### DIFF
--- a/src/shared/eslint.config.cjs
+++ b/src/shared/eslint.config.cjs
@@ -93,6 +93,7 @@ module.exports = defineConfig([
       'no-control-regex': 0,
       'no-sparse-arrays': 0,
       'prefer-const': 'warn',
+      'react/jsx-no-useless-fragment': ['warn', { allowExpressions: true }],
       'react/react-in-jsx-scope': 0,
       'react/prop-types': 0,
       'react/no-unknown-property': ['error', { ignore: ['global', 'jsx'] }],

--- a/src/shared/eslint.config.cjs
+++ b/src/shared/eslint.config.cjs
@@ -94,6 +94,7 @@ module.exports = defineConfig([
       'no-sparse-arrays': 0,
       'prefer-const': 'warn',
       'react/jsx-no-useless-fragment': ['warn', { allowExpressions: true }],
+      'react/no-unstable-nested-components': 'error',
       'react/react-in-jsx-scope': 0,
       'react/prop-types': 0,
       'react/no-unknown-property': ['error', { ignore: ['global', 'jsx'] }],


### PR DESCRIPTION
The first commit enables the [`react/jsx-no-useless-fragment`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-useless-fragment.md) rule at the `warning` level. This rule is automatically fixable. The `{ allowExpressions: true }` option prevents warnings on expressions, such as those in the `@tabnews/ui` [`StyledComponentsRegistry`](https://github.com/aprendendofelipe/tabnews/blob/cb753c42b55c548f6a72bfb12da2da1e964b5b6d/packages/ui/src/SCRegistry/SCRegistry.jsx):

```jsx
  useServerInsertedHTML(() => {
    const styles = styledComponentsStyleSheet.getStyleElement();
    styledComponentsStyleSheet.instance.clearTag();
    return <>{styles}</>;
  });


  if (typeof window !== 'undefined') return <>{children}</>;
```

The second commit enables the [`react/no-unstable-nested-components`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md) rule at the `error` level. This rule is important because we previously encountered a bug on `curso.dev` (https://github.com/filipedeschamps/curso.dev/pull/63), which this rule could have detected.

I've marked the second commit as a **breaking change** due to the `error` level and because it is not automatically fixable. Please let me know if this should not be considered a breaking change, and I will rewrite the commit message accordingly.

For reference, enabling these rules results in the following:

| Repository | Warnings | Errors |
| --- | --- | --- |
| [`@tabnews`](https://github.com/aprendendofelipe/tabnews) | 0 | 0 |
| [`tabnews.com.br`](https://github.com/filipedeschamps/tabnews.com.br/) | 7 | 4 |
| [`curso.dev`](https://github.com/filipedeschamps/curso.dev) | 7 | 6 |